### PR TITLE
MAINT: update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ conda:
 
 sphinx:
   builder: html
+  configuration: book/conf.py
   fail_on_warning: false
 
 formats:


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/